### PR TITLE
remove default props.open

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -130,6 +130,5 @@ Flyout.propTypes = {
 Flyout.defaultProps = {
 	closeOnBlur: true,
 	renderWhenClosed: true,
-	open: false,
 	element: 'div'
 };


### PR DESCRIPTION
I have an input field as a child of my flyout. This default prop of false is causing componentWillReceiveProps to always update state.open to false every time I type something in that input field, closing the flyout. 
