### PR TITLE
fix for react unknown props error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
 	"presets": [
 		"es2015",
 		"react"
-	]
+	],
+	"plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "happiness": "^6.0.7",

--- a/src/toggle.jsx
+++ b/src/toggle.jsx
@@ -7,7 +7,10 @@ export class FlyoutToggle extends React.Component {
 	}
 
 	render () {
-		return React.DOM[this.props.element](Object.assign({}, this.props, {
+		// don't pass unknown props to children: https://fb.me/react-unknown-prop
+		const { element, toggle, ...rest } = this.props; // eslint-disable-line
+
+		return React.DOM[this.props.element](Object.assign({}, rest, {
 			className: 'flyout-toggle ' + this.props.className,
 			onClick: this.onClick
 		}));


### PR DESCRIPTION
fix this for this react error.

```
Warning: Unknown props `element`, `toggle` on <button> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop
    in button (created by FlyoutToggle)
    in FlyoutToggle (created by ArchiveViewerPage)
```

react isn't thrilled with us passing unnecessary/unknown props to children.
also made this change in @streamme/autocomplete-container and just merged it.
obviously open to other methods to solve this.
